### PR TITLE
Add pylint and pyinstaller as license exemptions

### DIFF
--- a/templates/dependency-review.yml
+++ b/templates/dependency-review.yml
@@ -21,4 +21,5 @@ jobs:
       - name: "Dependency Review"
         uses: actions/dependency-review-action@v4
         with:
+          allow-dependencies-licenses: pkg:pypi/pylint, pkg:pypi/pyinstaller
           deny-licenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-1.0-or-later, AGPL-3.0-or-later, GPL-1.0-only, GPL-1.0-or-later, GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later


### PR DESCRIPTION
Update dependency-review with some license exemptions for:

pylint: GPL code, but not included in packager, dev linter only

pyinstaller: GPL - but with specific exemptions for using it to make distributions of your own code, the GPL license only applies when changing/editing pyinstaller code itself