### PR TITLE
renovate: Update NODELOCAL_DNS repository

### DIFF
--- a/templates/renovate-ips.json
+++ b/templates/renovate-ips.json
@@ -70,7 +70,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/\\.github/workflows/.+$/"],
       "matchStrings": ["NODELOCALDNS_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "kubernetes/dns",
+      "depNameTemplate": "kubernetes-sigs/node-local-dns",
       "datasourceTemplate": "github-tags"
     },
     {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects how Renovate detects/updates the `NODELOCALDNS_VERSION` dependency; potential impact is limited to dependency update PR generation.
> 
> **Overview**
> Updates Renovate’s regex custom manager for `NODELOCALDNS_VERSION` to track tags from `kubernetes-sigs/node-local-dns` instead of `kubernetes/dns`, ensuring Renovate pulls updates from the correct upstream repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d0a44c599e74ae3fd03fb9f495de3b191232435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->