### PR TITLE
Run go test makefile target tasks in parallel

### DIFF
--- a/templates/go-test.yml
+++ b/templates/go-test.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Test
-        run: make test
+        run: make -j6 -k test


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change isolated to CI; it only affects how tests execute and may surface race conditions or change failure reporting order.
> 
> **Overview**
> Speeds up CI by changing the Go test workflow to run `make test` with `-j6 -k`, enabling parallel execution of Makefile tasks while continuing other tasks after failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89be5843533c29c65bfc71784416e9e4a4fb9a96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->