### PR TITLE
Make gofmt run before other static analysis tools

### DIFF
--- a/templates/go-makefile
+++ b/templates/go-makefile
@@ -62,20 +62,16 @@ $(TEST_TARGETS): test
 check test tests: fmt lint vet staticcheck errcheck vulncheck; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
 	$Q $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
 
+.PHONY: fmt
+fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
+	$Q $(GO) fmt $(PKGS)
+
+# Run fmt before any linter so parallel `-jN` doesn't change files while a linter is mid flight.
+lint vet staticcheck errcheck vulncheck: fmt
+
 .PHONY: lint
 lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
 	$Q $(GOLINT) -set_exit_status $(PKGS)
-
-.PHONY: fmt
-fmt: ; $(info $(M) checking gofmt…) @ ## Verify gofmt on all source files
-	$Q out=$$(gofmt -l $$($(GO) list -f '{{`{{ .Dir }}`}}' $(PKGS))); \
-	   if [ -n "$$out" ]; then \
-	     echo "files need gofmt:"; echo "$$out"; exit 1; \
-	   fi
-
-.PHONY: fmt-fix
-fmt-fix: ; $(info $(M) running gofmt…) @ ## Rewrite files in-place with gofmt
-	$Q gofmt -w $$($(GO) list -f '{{`{{ .Dir }}`}}' $(PKGS))
 
 .PHONY: vet
 vet: ; $(info $(M) running go vet…) @ ## Run go vet on all source files

--- a/templates/go-makefile
+++ b/templates/go-makefile
@@ -68,7 +68,7 @@ lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
 
 .PHONY: fmt
 fmt: ; $(info $(M) checking gofmt…) @ ## Verify gofmt on all source files
-	$Q out=$$(gofmt -l $$($(GO) list -f '{{.Dir}}' $(PKGS)) | sort -u); \
+	$Q out=$$(gofmt -l $$($(GO) list -f '{{`{{ .Dir }}`}}' $(PKGS)) | sort -u); \
 	   if [ -n "$$out" ]; then \
 	     echo "files need gofmt:"; echo "$$out"; exit 1; \
 	   fi

--- a/templates/go-makefile
+++ b/templates/go-makefile
@@ -67,7 +67,14 @@ lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
 	$Q $(GOLINT) -set_exit_status $(PKGS)
 
 .PHONY: fmt
-fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
+fmt: ; $(info $(M) checking gofmt…) @ ## Verify gofmt on all source files
+	$Q out=$$(gofmt -l $$($(GO) list -f '{{.Dir}}' $(PKGS)) | sort -u); \
+	   if [ -n "$$out" ]; then \
+	     echo "files need gofmt:"; echo "$$out"; exit 1; \
+	   fi
+
+.PHONY: fmt-fix
+fmt-fix: ; $(info $(M) running gofmt…) @ ## Rewrite files in-place with gofmt
 	$Q $(GO) fmt $(PKGS)
 
 .PHONY: vet

--- a/templates/go-makefile
+++ b/templates/go-makefile
@@ -68,14 +68,14 @@ lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
 
 .PHONY: fmt
 fmt: ; $(info $(M) checking gofmt…) @ ## Verify gofmt on all source files
-	$Q out=$$(gofmt -l $$($(GO) list -f '{{`{{ .Dir }}`}}' $(PKGS)) | sort -u); \
+	$Q out=$$(gofmt -l $$($(GO) list -f '{{`{{ .Dir }}`}}' $(PKGS))); \
 	   if [ -n "$$out" ]; then \
 	     echo "files need gofmt:"; echo "$$out"; exit 1; \
 	   fi
 
 .PHONY: fmt-fix
 fmt-fix: ; $(info $(M) running gofmt…) @ ## Rewrite files in-place with gofmt
-	$Q $(GO) fmt $(PKGS)
+	$Q gofmt -w $$($(GO) list -f '{{`{{ .Dir }}`}}' $(PKGS))
 
 .PHONY: vet
 vet: ; $(info $(M) running go vet…) @ ## Run go vet on all source files


### PR DESCRIPTION
See https://github.com/Chia-Network/repo-content-updater/pull/120#discussion_r3184971218 for context

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Makefile dependency ordering change; may slightly increase runtime by running `fmt` before each static analysis target, but it avoids parallel `make -j` races on modified files.
> 
> **Overview**
> Ensures `fmt` runs before any static analysis by making `lint`, `vet`, `staticcheck`, `errcheck`, and `vulncheck` depend on `fmt`, preventing `make -j` from reformatting files while linters are running.
> 
> No analysis commands changed; this is purely a build/test workflow ordering update in `templates/go-makefile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d656c6095054b2ab3a80f2e6f40634b2628f7328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->