### PR TITLE
Revert "Make gofmt run before other static analysis tools"

### DIFF
--- a/templates/go-makefile
+++ b/templates/go-makefile
@@ -62,16 +62,13 @@ $(TEST_TARGETS): test
 check test tests: fmt lint vet staticcheck errcheck vulncheck; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
 	$Q $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
 
-.PHONY: fmt
-fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
-	$Q $(GO) fmt $(PKGS)
-
-# Run fmt before any linter so parallel `-jN` doesn't change files while a linter is mid flight.
-lint vet staticcheck errcheck vulncheck: fmt
-
 .PHONY: lint
 lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
 	$Q $(GOLINT) -set_exit_status $(PKGS)
+
+.PHONY: fmt
+fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
+	$Q $(GO) fmt $(PKGS)
 
 .PHONY: vet
 vet: ; $(info $(M) running go vet…) @ ## Run go vet on all source files


### PR DESCRIPTION
Reverts Chia-Network/repo-content-updater#121

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Makefile-only change, but it can reintroduce parallel `make -j` races where `fmt` runs concurrently with linters/vet/static analysis.
> 
> **Overview**
> Reverts the Makefile behavior that forced `fmt` to run before `lint`/`vet`/`staticcheck`/`errcheck`/`vulncheck` by removing the dependency chain and related comment.
> 
> `fmt` remains a standalone target (and is still listed in the `check`/`test` prerequisites), but other analysis targets no longer implicitly trigger or wait for formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b4b125234126a3b8220bfd9f79e50d227ce3fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->