### PR TITLE
Revert "Run go test makefile target tasks in parallel"

### DIFF
--- a/templates/go-test.yml
+++ b/templates/go-test.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Test
-        run: make -j6 -k test
+        run: make test


### PR DESCRIPTION
Reverts Chia-Network/repo-content-updater#120

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that removes parallel `make` flags; main impact is potentially longer test runtime but fewer flaky/racy failures.
> 
> **Overview**
> Reverts the Go test workflow template to run tests via plain `make test` instead of invoking `make` with parallel/keep-going flags (`-j6 -k`). This makes CI test execution sequential and stops on first failing target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23126b9a03a4600190a815f2bee091a8b17e0920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->