### PR TITLE
Specific 5.0.0 version since this is how dependabot likes it now

### DIFF
--- a/templates/dependency-review.yml
+++ b/templates/dependency-review.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: "Dependency Review"
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@v5.0.0
         with:
           allow-dependencies-licenses: {{ .DEPENDENCY_REVIEW_ALLOW_DEPENDENCIES_LICENSES }}
           deny-licenses: {{ .DEPENDABOT_DENY_LICENSES }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only pins the GitHub Action version tag from `v5` to the explicit `v5.0.0`, with no changes to workflow logic or permissions.
> 
> **Overview**
> Pins the `actions/dependency-review-action` used by the `dependency-review` workflow template to the explicit `v5.0.0` tag instead of the floating `v5` tag, aligning with Dependabot’s preferred version format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1af2ef35f5dcfb0cd77305642f30b665bc0361a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->