### PR TITLE
Allow bypassing PR if a repo opts in

### DIFF
--- a/cmd/debugProperties.go
+++ b/cmd/debugProperties.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/chia-network/repo-content-updater/internal/repo"
+)
+
+// debugPropertiesCmd prints the resolved CustomProperties for each repo
+var debugPropertiesCmd = &cobra.Command{
+	Use:   "debug-properties",
+	Short: "Prints the resolved custom properties for repos in the org",
+	Long: `Fetches GitHub org custom properties and prints the values that
+repo-content-updater would use for each repo. Use --repo to inspect a single repo.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		content, err := repo.NewContent(
+			viper.GetString("templates"),
+			viper.GetString("github-org"),
+			viper.GetString("committer-name"),
+			viper.GetString("committer-email"),
+			viper.GetString("review-team"),
+			viper.GetString("github-token"),
+		)
+		if err != nil {
+			log.Fatalf("Error creating content manager: %s", err.Error())
+		}
+
+		properties, err := content.GetResolvedProperties(viper.GetString("repo"))
+		if err != nil {
+			log.Fatalf("Error fetching properties: %s", err.Error())
+		}
+
+		if len(properties) == 0 {
+			fmt.Println("No repos found.")
+			return
+		}
+
+		repos := make([]string, 0, len(properties))
+		for r := range properties {
+			repos = append(repos, r)
+		}
+		sort.Strings(repos)
+
+		for _, r := range repos {
+			props := properties[r]
+			fmt.Printf("%s:\n", r)
+			fmt.Printf("  bypass-pr: %v\n", props.BypassPR)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(debugPropertiesCmd)
+}

--- a/cmd/debugRepo.go
+++ b/cmd/debugRepo.go
@@ -32,7 +32,7 @@ var debugRepoCmd = &cobra.Command{
 			log.Fatalf("error loading config: %s\n", err.Error())
 		}
 
-		err = content.CheckFiles(viper.GetString("repo"), viper.GetStringSlice("file"), cfg)
+		err = content.CheckFiles(viper.GetString("repo"), viper.GetStringSlice("file"), cfg, repo.CustomProperties{})
 		if err != nil {
 			log.Fatalf("Error checking repo: %s", err.Error())
 		}

--- a/internal/repo/content.go
+++ b/internal/repo/content.go
@@ -170,10 +170,18 @@ func (c *Content) commit(w *git.Worktree, repoName string, message string) error
 	return nil
 }
 
+// CustomProperties holds org custom property values for a single repo that
+// are relevant to this tool. It is intentionally a struct so additional
+// properties can be added here without changing call sites.
+type CustomProperties struct {
+	BypassPR bool
+}
+
 type pushAndPROptions struct {
 	PrTargetBranch *string
 	AssignUsers    []string
 	AssignGroup    *string
+	BypassPR       bool
 }
 
 func (c *Content) pushAndPR(r *git.Repository, repoName, branchName, title string, opts *pushAndPROptions) error {
@@ -181,6 +189,23 @@ func (c *Content) pushAndPR(r *git.Repository, repoName, branchName, title strin
 		log.Println("Skipping push, complete")
 		return nil
 	}
+
+	if opts.BypassPR {
+		err := r.Push(&git.PushOptions{
+			RefSpecs: []config.RefSpec{
+				config.RefSpec(fmt.Sprintf("refs/heads/%s:refs/heads/%s", branchName, *opts.PrTargetBranch)),
+			},
+		})
+		if err != nil {
+			if errors.Is(err, git.NoErrAlreadyUpToDate) {
+				return fmt.Errorf("branch was already up to date even though there were changes")
+			}
+			return err
+		}
+		log.Printf("Pushed directly to %s (bypass PR)\n", *opts.PrTargetBranch)
+		return nil
+	}
+
 	// Push the new branch to the remote
 	err := r.Push(&git.PushOptions{
 		Force: true, // Force push in case there are updates to an old unmerged existing version of this branch

--- a/internal/repo/files.go
+++ b/internal/repo/files.go
@@ -15,10 +15,14 @@ import (
 	"github.com/chia-network/repo-content-updater/internal/config"
 )
 
+type repoFilesEntry struct {
+	files []string
+	props CustomProperties
+}
+
 // ManagedFiles updates all managed files in the org with current versions
 func (c *Content) ManagedFiles(cfg *config.Config, onlyRepo string) error {
-	// repo: [file, file, file]
-	reposToCheck := map[string][]string{}
+	reposToCheck := map[string]repoFilesEntry{}
 
 	opts := &github.ListOptions{
 		Page:    0,
@@ -37,10 +41,9 @@ func (c *Content) ManagedFiles(cfg *config.Config, onlyRepo string) error {
 			if onlyRepo != "" && !strings.EqualFold(repo.RepositoryName, onlyRepo) {
 				continue
 			}
+			entry := reposToCheck[repo.RepositoryName]
 			for _, property := range repo.Properties {
 				if property.PropertyName == "managed-files" && property.Value != nil {
-					reposToCheck[repo.RepositoryName] = []string{}
-
 					var finalFiles []string
 					files := strings.Split(*property.Value, ",")
 					for _, file := range files {
@@ -59,9 +62,11 @@ func (c *Content) ManagedFiles(cfg *config.Config, onlyRepo string) error {
 						}
 					}
 
-					reposToCheck[repo.RepositoryName] = finalFiles
+					entry.files = finalFiles
 				}
 			}
+			entry.props = parseCustomProperties(repo.Properties)
+			reposToCheck[repo.RepositoryName] = entry
 		}
 
 		if resp.NextPage == 0 {
@@ -69,9 +74,12 @@ func (c *Content) ManagedFiles(cfg *config.Config, onlyRepo string) error {
 		}
 	}
 
-	for repo, files := range reposToCheck {
+	for repo, entry := range reposToCheck {
+		if entry.files == nil {
+			continue
+		}
 		log.Printf("Need to check %s\n", repo)
-		err := c.CheckFiles(repo, files, cfg)
+		err := c.CheckFiles(repo, entry.files, cfg, entry.props)
 		if err != nil {
 			log.Printf("Error updating %s: %s\n", repo, err.Error())
 			continue
@@ -82,7 +90,7 @@ func (c *Content) ManagedFiles(cfg *config.Config, onlyRepo string) error {
 }
 
 // CheckFiles checks all the files for updates in the repo
-func (c *Content) CheckFiles(repoName string, files []string, cfg *config.Config) error {
+func (c *Content) CheckFiles(repoName string, files []string, cfg *config.Config, props CustomProperties) error {
 	defer removeDirIfExists(repoDir(repoName))
 
 	r, w, err := c.cloneRepo(repoName)
@@ -204,9 +212,10 @@ func (c *Content) CheckFiles(repoName string, files []string, cfg *config.Config
 
 	if hadChanges {
 		return c.pushAndPR(r, repoName, branchName, "Update Managed Files", &pushAndPROptions{
-			PrTargetBranch: &DefaultBranch,         // Directly using the pointer from repoConfig
-			AssignUsers:    repoConfig.AssignUsers, // Assuming AssignUsers is a slice of strings
-			AssignGroup:    repoConfig.AssignGroup, // Directly using the pointer from repoConfig
+			PrTargetBranch: &DefaultBranch,
+			AssignUsers:    repoConfig.AssignUsers,
+			AssignGroup:    repoConfig.AssignGroup,
+			BypassPR:       props.BypassPR,
 		})
 	}
 

--- a/internal/repo/license.go
+++ b/internal/repo/license.go
@@ -16,7 +16,7 @@ import (
 
 // CheckLicenses checks all repos for licenses that need to be managed/updated
 func (c *Content) CheckLicenses(cfg *config.Config, onlyRepo string) error {
-	var reposToCheck []string
+	reposToCheck := map[string]CustomProperties{}
 
 	opts := &github.ListOptions{
 		Page:    0,
@@ -35,10 +35,14 @@ func (c *Content) CheckLicenses(cfg *config.Config, onlyRepo string) error {
 			if onlyRepo != "" && !strings.EqualFold(repo.RepositoryName, onlyRepo) {
 				continue
 			}
+			manageLicense := false
 			for _, property := range repo.Properties {
 				if property.PropertyName == "manage-license" && property.Value != nil && *property.Value == "yes" {
-					reposToCheck = append(reposToCheck, repo.RepositoryName)
+					manageLicense = true
 				}
+			}
+			if manageLicense {
+				reposToCheck[repo.RepositoryName] = parseCustomProperties(repo.Properties)
 			}
 		}
 
@@ -47,9 +51,9 @@ func (c *Content) CheckLicenses(cfg *config.Config, onlyRepo string) error {
 		}
 	}
 
-	for _, repo := range reposToCheck {
+	for repo, props := range reposToCheck {
 		log.Printf("Need to check %s\n", repo)
-		err := c.UpdateLicense(repo, cfg)
+		err := c.UpdateLicense(repo, cfg, props)
 		if err != nil {
 			log.Printf("Error updating %s: %s\n", repo, err.Error())
 			continue
@@ -60,7 +64,7 @@ func (c *Content) CheckLicenses(cfg *config.Config, onlyRepo string) error {
 }
 
 // UpdateLicense ensures the license is up to date for the given repo
-func (c *Content) UpdateLicense(repoName string, cfg *config.Config) error {
+func (c *Content) UpdateLicense(repoName string, cfg *config.Config, props CustomProperties) error {
 	defer removeDirIfExists(repoDir(repoName))
 
 	r, w, err := c.cloneRepo(repoName)
@@ -163,8 +167,9 @@ func (c *Content) UpdateLicense(repoName string, cfg *config.Config) error {
 	}
 
 	return c.pushAndPR(r, repoName, branchName, "Updated License", &pushAndPROptions{
-		PrTargetBranch: &DefaultBranch,         // Directly using the pointer from repoConfig
-		AssignUsers:    repoConfig.AssignUsers, // Assuming AssignUsers is a slice of strings
-		AssignGroup:    repoConfig.AssignGroup, // Directly using the pointer from repoConfig
+		PrTargetBranch: &DefaultBranch,
+		AssignUsers:    repoConfig.AssignUsers,
+		AssignGroup:    repoConfig.AssignGroup,
+		BypassPR:       props.BypassPR,
 	})
 }

--- a/internal/repo/properties.go
+++ b/internal/repo/properties.go
@@ -1,0 +1,69 @@
+package repo
+
+import (
+	"context"
+
+	"github.com/google/go-github/v59/github"
+)
+
+// GetResolvedProperties fetches custom properties and returns the parsed
+// CustomProperties for each repo. If onlyRepo is set, a single targeted
+// API call is made for that repo instead of paginating the full org list.
+func (c *Content) GetResolvedProperties(onlyRepo string) (map[string]CustomProperties, error) {
+	if onlyRepo != "" {
+		return c.getResolvedPropertiesForRepo(onlyRepo)
+	}
+	return c.getResolvedPropertiesForOrg()
+}
+
+func (c *Content) getResolvedPropertiesForRepo(repoName string) (map[string]CustomProperties, error) {
+	values, _, err := ghDo(func() ([]*github.CustomPropertyValue, *github.Response, error) {
+		return c.githubClient.Repositories.GetAllCustomPropertyValues(context.TODO(), c.githubOrg, repoName)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]CustomProperties{
+		repoName: parseCustomProperties(values),
+	}, nil
+}
+
+func (c *Content) getResolvedPropertiesForOrg() (map[string]CustomProperties, error) {
+	result := map[string]CustomProperties{}
+
+	opts := &github.ListOptions{
+		Page:    0,
+		PerPage: 100,
+	}
+	for {
+		opts.Page++
+		repos, resp, err := ghDo(func() ([]*github.RepoCustomPropertyValue, *github.Response, error) {
+			return c.githubClient.Organizations.ListCustomPropertyValues(context.TODO(), c.githubOrg, opts)
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, repo := range repos {
+			result[repo.RepositoryName] = parseCustomProperties(repo.Properties)
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+// parseCustomProperties extracts the tool-relevant custom properties from
+// a repo's raw GitHub property list.
+func parseCustomProperties(properties []*github.CustomPropertyValue) CustomProperties {
+	var props CustomProperties
+	for _, p := range properties {
+		if p.PropertyName == "repo-content-updater-bypass-pr" && p.Value != nil && *p.Value == "true" {
+			props.BypassPR = true
+		}
+	}
+	return props
+}

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,12 @@ files:
 * `repo_path` is the path within the repo to place the file
 * `alternate_paths` is a list of alternate/equivalent paths this template might have been named before being managed. These files will be renamed and updated to the latest version of the template, if present
 
+## Bypass PR
+
+Set the `repo-content-updater-bypass-pr` custom property to `true` on a repo to opt into direct commits to the target branch instead of opening a pull request. This property uses GitHub's boolean custom property type. When the property is absent or `false`, the default PR-based workflow is used.
+
+This applies to both the `license` and `managed-files` commands.
+
 ## Repo Overrides
 
 If you need to override any of the default settings on a per-repo basis, you can create a [.repo-content-updater.yaml](examples/.repo-content-updater.yaml) file in the root of the repo, and configure any overrides there. It must be present in the default branch of the repo to be loaded.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Opt-in repos skip PR review and push directly to protected target branches, which is a high-impact change to how automated updates land in production code.
> 
> **Overview**
> Repos can opt out of pull requests by setting the GitHub custom property **`repo-content-updater-bypass-pr`** to **`true`**. The updater reads that flag via a new **`CustomProperties`** struct (starting with **`BypassPR`**) and threads it through **`license`** and **`managed-files`** into **`pushAndPR`**, which either opens a PR as before or **pushes the working branch straight to the PR target branch** with a refspec (no force push, no reviewers).
> 
> Property resolution is centralized in **`parseCustomProperties`** / **`GetResolvedProperties`**, with a new **`debug-properties`** CLI to print resolved values per repo. **`debug-repo`** passes empty properties so local debugging still uses the PR path. README documents the opt-in behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c1222b9df006242f2b0877051a6d4c8d741487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->