### PR TITLE
renovate: LOKI_CHART_VERSION

### DIFF
--- a/templates/renovate-ips.json
+++ b/templates/renovate-ips.json
@@ -118,6 +118,14 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/\\.github/workflows/.+$/"],
+      "matchStrings": ["LOKI_CHART_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "grafana-community/helm-charts",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^loki-(?<version>\\d+\\.\\d+\\.\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/\\.github/workflows/.+$/"],
       "matchStrings": ["ALLOY_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "grafana/alloy",
       "datasourceTemplate": "github-tags",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only change to Renovate dependency detection; no runtime or deployment logic is modified.
> 
> **Overview**
> Adds a Renovate **regex custom manager** in `templates/renovate-ips.json` so `LOKI_CHART_VERSION` in GitHub workflow files is tracked separately from `LOKI_VERSION`.
> 
> The new rule reads `LOKI_CHART_VERSION` from `.github/workflows/*`, maps it to **`grafana-community/helm-charts`** on GitHub tags, and parses versions from tags like `loki-x.y.z`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07deab5b47aab4bd7eee176b0037f34a4a25d484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->