### PR TITLE
add renovate checks for contour

### DIFF
--- a/templates/renovate-ips.json
+++ b/templates/renovate-ips.json
@@ -69,6 +69,16 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/\\.github/workflows/.+$/"],
+      "matchStrings": [
+        "CONTOUR_CHART_VERSION:\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "projectcontour/contour",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^chart-v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/\\.github/workflows/.+$/"],
       "matchStrings": ["NODELOCALDNS_VERSION:\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "kubernetes-sigs/node-local-dns",
       "datasourceTemplate": "github-tags"

--- a/templates/renovate-ips.json
+++ b/templates/renovate-ips.json
@@ -72,9 +72,9 @@
       "matchStrings": [
         "CONTOUR_CHART_VERSION:\\s*\"(?<currentValue>[^\"]+)\""
       ],
-      "depNameTemplate": "projectcontour/contour",
+      "depNameTemplate": "projectcontour/helm-charts",
       "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^chart-v(?<version>.+)$"
+      "extractVersionTemplate": "^contour-(?<version>.+)$"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Configuration-only change to Renovate; no runtime or deployment behavior is modified.
> 
> **Overview**
> **Renovate** can now bump **Contour** Helm chart versions pinned in GitHub Actions workflows.
> 
> A new regex custom manager in `templates/renovate-ips.json` watches `CONTOUR_CHART_VERSION` in workflow files, tracks `projectcontour/helm-charts` GitHub tags, and normalizes versions with the `contour-<version>` tag prefix—same pattern as the existing ingress-nginx chart manager.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c218fb461379dfc8a6687124c247de3ae320da9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->