### PR TITLE
Add conditional for Cursor analysis step

### DIFF
--- a/templates/dependency-cursor-review.yml
+++ b/templates/dependency-cursor-review.yml
@@ -766,6 +766,7 @@ jobs:
           fi
 
       - name: Run Cursor analysis
+        if: github.repository_owner == 'Chia-Network'
         timeout-minutes: 10
         env:
           CURSOR_API_KEY: ${{`{{ secrets.CURSOR_API_KEY }}`}}


### PR DESCRIPTION
This pull request introduces a conditional step in the dependency cursor review workflow to ensure the Cursor analysis only runs for repositories owned by `Chia-Network`.

Workflow adjustment:

* Added a condition to the "Run Cursor analysis" step in `dependency-cursor-review.yml` so it only executes when the repository owner is `Chia-Network`.