### PR TITLE
Move the owner check to the whole job, not just the one step

### DIFF
--- a/templates/dependency-cursor-review.yml
+++ b/templates/dependency-cursor-review.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   dependency-review:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'))
+    if: github.repository_owner == 'Chia-Network' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]')))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -766,7 +766,6 @@ jobs:
           fi
 
       - name: Run Cursor analysis
-        if: github.repository_owner == 'Chia-Network'
         timeout-minutes: 10
         env:
           CURSOR_API_KEY: ${{`{{ secrets.CURSOR_API_KEY }}`}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow gating only; no runtime app or secret-handling logic changes beyond avoiding unnecessary job runs outside Chia-Network.
> 
> **Overview**
> The **Dependency Cursor Review** workflow now requires `github.repository_owner == 'Chia-Network'` on the **`dependency-review` job**, not only on the **Run Cursor analysis** step.
> 
> Forks and other orgs that reuse this template will skip the entire job (PR resolution, checkout, malware scan, Cursor CLI, PR comments) when the owner is not Chia-Network, instead of running most steps and skipping only Cursor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc251ea71045bcba8b28dc721b99a64bce30f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->