### PR TITLE
Add x509 exporter

### DIFF
--- a/templates/renovate-ips.json
+++ b/templates/renovate-ips.json
@@ -181,6 +181,16 @@
       "depNameTemplate": "nats-io/k8s",
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^nats-(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/\\.github/workflows/.+$/"],
+      "matchStrings": [
+        "X509_CERTIFICATE_EXPORTER_CHART_VERSION:\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "enix/x509-certificate-exporter",
+      "datasourceTemplate": "github-tags",
+      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only change to Renovate dependency tracking; no runtime or deployment behavior is modified in this diff.
> 
> **Overview**
> Adds a **Renovate** regex custom manager in `templates/renovate-ips.json` so `X509_CERTIFICATE_EXPORTER_CHART_VERSION` in `.github/workflows` files is kept in sync with **enix/x509-certificate-exporter** GitHub releases (tags parsed with `^v(?<version>.+)$`).
> 
> This follows the same pattern as other workflow-pinned chart versions (e.g. NATS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a17de0f90629eccfde2d55bc0fed118c3458b4aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->