### PR TITLE
Add permissions to the templates

### DIFF
--- a/.github/workflows/check-commit-signing.yml
+++ b/.github/workflows/check-commit-signing.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/templates/check-commit-signing.yml
+++ b/templates/check-commit-signing.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{`{{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}`}}
   cancel-in-progress: true

--- a/templates/go-test.yml
+++ b/templates/go-test.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Restricts GITHUB_TOKEN to read-only contents access; no functional workflow logic changes.
> 
> **Overview**
> Adds explicit `permissions: contents: read` to the `check-commit-signing` and `go-test` workflows (and their matching templates), aligning them with other workflows that already declare least-privilege token access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf2047307d56333954f27e6090813b6740c2936b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->